### PR TITLE
Changed back to ubuntu-runners for public repo.

### DIFF
--- a/.github/workflows/build-publish-dev.yml
+++ b/.github/workflows/build-publish-dev.yml
@@ -6,7 +6,7 @@ on:
     types: ['closed']
 jobs:
   build-publish:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
# Changes Summary

Public repositories don't allow running on self-hosted runners (for security reasons, they're valid), reverting the org-wide change made for private repos on this public repo. 

# Forecast Ticket Link(s)



# FE Screenshots (If Applicable)



# Author Checklist

- [ ]  Can a reviewer skim this PR / Is this a non code change?
- [ ]  Followed DRY (Don't repeat yourself)
- [ ]  Migrations Required/Applied?
- [ ]  Dependency Updates Required
- [ ]  Tests Added
- [ ]  Documentation Updated (If Applicable)
